### PR TITLE
Remove extra quotes

### DIFF
--- a/imei.sh
+++ b/imei.sh
@@ -415,7 +415,7 @@ install_aom() {
   if {
     echo -ne ' Building aom                  [..]\r'
 
-    if [ "$(version "$CMAKE_VERSION")" -lt "$(version 3.6)" ]; then
+    if [ "$(version $CMAKE_VERSION)" -lt "$(version 3.6)" ]; then
         echo -ne " Building aom                  [${CYELLOW}SKIPPED (CMAKE version not sufficient)${CEND}]\\r"
         echo ""
 


### PR DESCRIPTION
## What does this PR do?

Fixes a bug when comparing the cmake version which was always returning a version lower than expected, even though the version is bigger. Removing the extra quotes when passing the version to the `version()` function seems to fix it.


### Have you read the [Code of Conduct](https://github.com/SoftCreatR/imei/blob/main/CODE_OF_CONDUCT.md)?

[x] I have read the Code of Conduct

