### PR TITLE
imei.sh: fix aom cmake flags

### DIFF
--- a/imei.sh
+++ b/imei.sh
@@ -526,16 +526,16 @@ install_aom() {
         fi
 
         # see https://github.com/SoftCreatR/imei/issues/9
-        CMAKE_FLAGS="-DBUILD_SHARED_LIBS=1 -DENABLE_DOCS=0 -DENABLE_TESTS=0 -DENABLE_CCACHE=1"
+        CMAKE_FLAGS=(-DBUILD_SHARED_LIBS=1 -DENABLE_DOCS=0 -DENABLE_TESTS=0 -DENABLE_CCACHE=1)
 
         if [[ "${OS_DISTRO,,}" == *"raspbian"* ]]; then
-          CMAKE_FLAGS+=' -DCMAKE_C_FLAGS="-mfloat-abi=hard -march=armv7-a -marm -mfpu=neon"'
+          CMAKE_FLAGS+=(-DCMAKE_C_FLAGS="-mfloat-abi=hard -march=armv7-a -marm -mfpu=neon")
         fi
 
         tar -xf "aom-$AOM_VER.tar.gz" &&
           mkdir "$WORK_DIR/build_aom" &&
           cd "$WORK_DIR/build_aom" &&
-          cmake "../aom-$AOM_VER/" $CMAKE_FLAGS &&
+          cmake "../aom-$AOM_VER/" "${CMAKE_FLAGS[@]}" &&
           make
 
           if [ -n "$CHECKINSTALL" ]; then

--- a/imei.sh
+++ b/imei.sh
@@ -8,7 +8,7 @@
 # Author         : Sascha Greuel <hello@1-2.dev>             #
 # Date           : 2022-08-31 09:01                          #
 # License        : ISC                                       #
-# Version        : 6.6.3                                     #
+# Version        : 6.6.4                                     #
 #                                                            #
 # Usage          : bash ./imei.sh                            #
 ##############################################################
@@ -535,7 +535,7 @@ install_aom() {
         tar -xf "aom-$AOM_VER.tar.gz" &&
           mkdir "$WORK_DIR/build_aom" &&
           cd "$WORK_DIR/build_aom" &&
-          cmake "../aom-$AOM_VER/" "$CMAKE_FLAGS" &&
+          cmake "../aom-$AOM_VER/" $CMAKE_FLAGS &&
           make
 
           if [ -n "$CHECKINSTALL" ]; then


### PR DESCRIPTION
## What does this PR do?

convert CMAKE_FLAGS to an array. previously CMAKE_FLAGS was a string and
quoting it would pass it as a single parameter causing the flags to be ignored. 

## Test Plan

Invoke imei.sh and verify cmake invocation in imei.log

## Related PRs and Issues

fixes #69

### Have you read the [Code of Conduct](https://github.com/SoftCreatR/imei/blob/main/CODE_OF_CONDUCT.md)?

[x ] I have read the Code of Conduct

