### PR TITLE
fix: missing aom repo

### DIFF
--- a/imei.sh
+++ b/imei.sh
@@ -620,7 +620,7 @@ install_aom() {
 
     {
       if [ -n "$AOM_VER" ]; then
-        httpGet "https://aomedia.googlesource.com/aom/+archive/v$AOM_VER.tar.gz" >"aom-$AOM_VER.tar.gz"
+        httpGet "$GH_FILE_BASE/SoftCreatR/aom/tar.gz/v$AOM_VER" >"aom-$AOM_VER.tar.gz"
 
         if [ -n "$AOM_HASH" ]; then
           if [ "$(sha1sum "aom-$AOM_VER.tar.gz" | cut -b-40)" != "$AOM_HASH" ]; then
@@ -637,8 +637,8 @@ install_aom() {
         if [[ "${OS_DISTRO,,}" == *"raspbian"* ]]; then
           CMAKE_FLAGS+=(-DCMAKE_C_FLAGS="-mfloat-abi=hard -march=armv7-a -marm -mfpu=neon")
         fi
-        mkdir -p "$WORK_DIR/aom-$AOM_VER"
-        tar -xf "aom-$AOM_VER.tar.gz" -C "$WORK_DIR/aom-$AOM_VER" &&
+
+        tar -xf "aom-$AOM_VER.tar.gz" &&
           mkdir "$WORK_DIR/build_aom" &&
           cd "$WORK_DIR/build_aom" &&
           cmake "../aom-$AOM_VER/" "${CMAKE_FLAGS[@]}" &&

--- a/imei.sh
+++ b/imei.sh
@@ -620,7 +620,7 @@ install_aom() {
 
     {
       if [ -n "$AOM_VER" ]; then
-        httpGet "$GH_FILE_BASE/jbeich/aom/tar.gz/v$AOM_VER" >"aom-$AOM_VER.tar.gz"
+        httpGet "https://aomedia.googlesource.com/aom/+archive/v$AOM_VER.tar.gz" >"aom-$AOM_VER.tar.gz"
 
         if [ -n "$AOM_HASH" ]; then
           if [ "$(sha1sum "aom-$AOM_VER.tar.gz" | cut -b-40)" != "$AOM_HASH" ]; then
@@ -637,8 +637,8 @@ install_aom() {
         if [[ "${OS_DISTRO,,}" == *"raspbian"* ]]; then
           CMAKE_FLAGS+=(-DCMAKE_C_FLAGS="-mfloat-abi=hard -march=armv7-a -marm -mfpu=neon")
         fi
-
-        tar -xf "aom-$AOM_VER.tar.gz" &&
+        mkdir -p "$WORK_DIR/aom-$AOM_VER"
+        tar -xf "aom-$AOM_VER.tar.gz" -C "$WORK_DIR/aom-$AOM_VER" &&
           mkdir "$WORK_DIR/build_aom" &&
           cd "$WORK_DIR/build_aom" &&
           cmake "../aom-$AOM_VER/" "${CMAKE_FLAGS[@]}" &&

--- a/update_version_info.sh
+++ b/update_version_info.sh
@@ -100,7 +100,7 @@ fi
 
 # Get version information and write it to files
 IMAGEMAGICK_VER=$(getVersionInfoAndWriteToFile "ImageMagick/ImageMagick" '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?$' "$WORKDIR/versions/imagemagick.version" "$WORKDIR/versions/imagemagick.hash")
-LIBAOM_VER=$(getVersionInfoAndWriteToFile "jbeich/aom" '^v[0-9]+\.[0-9]+\.[0-9]+$' "$WORKDIR/versions/aom.version" "$WORKDIR/versions/aom.hash")
+LIBAOM_VER=$(getVersionInfoAndWriteToFile "SoftCreatR/aom" '^v[0-9]+\.[0-9]+\.[0-9]+$' "$WORKDIR/versions/aom.version" "$WORKDIR/versions/aom.hash")
 LIBHEIF_VER=$(getVersionInfoAndWriteToFile "strukturag/libheif" '^v[0-9]+\.[0-9]+\.[0-9]+$' "$WORKDIR/versions/libheif.version" "$WORKDIR/versions/libheif.hash")
 LIBJXL_VER=$(getVersionInfoAndWriteToFile "libjxl/libjxl" '^v[0-9]+\.[0-9]+(\.[0-9]+)?$' "$WORKDIR/versions/libjxl.version" "$WORKDIR/versions/libjxl.hash")
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

-->

## What does this PR do?

This PR fixes an issue where the current aom repo `jbeich/aom` is missing.
It's using the [google repo](https://aomedia.googlesource.com/aom) for "Alliance for Open Media"

## Test Plan

Run the installation without having aom installed.

### Have you read the [Code of Conduct](https://github.com/SoftCreatR/imei/blob/main/CODE_OF_CONDUCT.md)?

- [x] I have read the Code of Conduct



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved installation process for ImageMagick and its dependencies with enhanced error handling and clearer feedback.
	- Added version checks to prevent unnecessary installations of AOM, libheif, and JPEG XL.
	- Updated source URL for the AOM library to the SoftCreatR organization for better reliability.

- **Bug Fixes**
	- Enhanced integrity verification for downloaded files using SHA1 checksums.

- **Chores**
	- Updated repository reference for the AOM library in version information scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->